### PR TITLE
Add spec doc sheet status

### DIFF
--- a/app/Http/Controllers/SpecDocSheetController.php
+++ b/app/Http/Controllers/SpecDocSheetController.php
@@ -6,6 +6,7 @@ use App\Domain\SpecDocItem\SpecDocItemFactory;
 use App\Domain\SpecDocItem\ValueObject\StatusId;
 use App\Domain\SpecDocSheet\SpecDocSheetDto;
 use App\Domain\SpecDocSheet\SpecDocSheetFactory;
+use App\Domain\SpecDocSheet\ValueObject\StatusId as SpecDocSheetStatusId;
 use App\Domain\SpecificationDocument\SpecificationDocumentFactory;
 use App\Http\Requests\SpecDocSheetRequest;
 use App\UseCases\SpecDocItem\SpecDocItemFindAction;
@@ -45,6 +46,7 @@ class SpecDocSheetController extends Controller
         return Inertia::render('SpecDocSheet/Index', [
             'specDoc'       => SpecificationDocumentFactory::create($specDocDto)->toArray(),
             'specDocSheets' => $specDocSheets,
+            'sheetStatuses' => SpecDocSheetStatusId::STATUSES,
         ]);
     }
 

--- a/app/Infrastructure/Repositories/SpecDocItemRepository.php
+++ b/app/Infrastructure/Repositories/SpecDocItemRepository.php
@@ -24,7 +24,8 @@ final class SpecDocItemRepository implements SpecDocItemRepositoryInterface
     public function findById(int $id): SpecDocItemDto
     {
         /** @var stdClass */
-        $model = DB::table(self::TABLE_NAME . ' as sds')
+        $model = DB::table(self::TABLE_NAME)
+            ->where('id', $id)
             ->first();
 
         return new SpecDocItemDto(

--- a/resources/ts/Pages/SpecDocSheet/Index.tsx
+++ b/resources/ts/Pages/SpecDocSheet/Index.tsx
@@ -11,9 +11,10 @@ import { SpecificationDocument } from "@/types/SpecificationDocument";
 type Props = PageProps & {
     specDoc: SpecificationDocument;
     specDocSheets: SpecDocSheet[];
+    sheetStatuses: { [key:number]: string };
 };
 
-const Index: React.FC<Props> = ({ auth, specDoc, specDocSheets }) => {
+const Index: React.FC<Props> = ({ auth, specDoc, specDocSheets, sheetStatuses }) => {
     return (
         <AuthenticatedLayout
             user={auth.user}
@@ -70,6 +71,7 @@ const Index: React.FC<Props> = ({ auth, specDoc, specDocSheets }) => {
                                 })}
                             >
                                 <h3>{specDocSheet.execEnvName}</h3>
+                                <span>{sheetStatuses[specDocSheet.statusId]}</span>
                             </Link>
                         </li>
                     ))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - スペックドキュメントシートのステータス情報を表示するための新しいプロパティ `sheetStatuses` を追加しました。
  
- **改善**
  - スペックドキュメントシートのデータを取得する際に、関連アイテムのステータス情報を集約する機能を強化しました。
  - 特定のIDに基づいて正しいレコードを取得するためのメソッドを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->